### PR TITLE
Improvements: Cut decode speed by half, readme updates, unused things

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ goos: darwin
 goarch: amd64
 pkg: github.com/theMPatel/streamvbyte-simdgo/pkg/decode
 cpu: Intel(R) Core(TM) i7-8700B CPU @ 3.20GHz
-BenchmarkGet8uint32Fast-12      	195934500	         6.112 ns/op
-BenchmarkGet8uint32Scalar-12    	23029934	        52.48 ns/op
+BenchmarkGet8uint32Fast-12      	319653280	         3.754 ns/op
+BenchmarkGet8uint32Scalar-12    	22984789	        51.96 ns/op
 
 goos: darwin
 goarch: amd64
@@ -247,7 +247,7 @@ is more clear if you look at an example using a 3-byte integer.
 The signed 16-bit min operation has three important effects.
 
 First, for 3-byte integers, it has the effect of turning off the MSB of the lowest byte. This is necessary
-because a 3-byte integer should have a control bit that is `0b10` and without this step using the MSB pack
+because a 3-byte integer should have a 2-bit control that is `0b10` and without this step using the MSB pack
 operation would result in a 2-bit control that looks something like `0b_1`, where the lowest bit is on.
 Obviously this is wrong, since only integers that require 2 or 4 bytes to encode should have that lower bit
 on, i.e. 1 or 3 as a zero-indexed length.

--- a/pkg/decode/decode.go
+++ b/pkg/decode/decode.go
@@ -8,7 +8,6 @@ import (
 
 var (
 	getImpl Get8Impl
-	zeroSlice = make([]byte, 4)
 )
 
 type Get8Impl func(in []byte, out []uint32, ctrl uint16) int

--- a/pkg/decode/decode_amd64.go
+++ b/pkg/decode/decode_amd64.go
@@ -15,17 +15,13 @@ func GetMode() shared.PerformanceMode {
 }
 
 func get8uint32(in []byte, out []uint32, ctrl uint16) int {
-	// bounds check to prevent undefined behavior
-	_ = in[7] // best effort, there should be at least 8 bytes
-	_ = out[7]
-	lower, upper := uint8(ctrl&0xff), uint8(ctrl>>8)
-	sizeLower, sizeUpper := shared.PerControlLenTable[lower], shared.PerControlLenTable[upper]
-	get8uint32Fast(in, out,
-		&shared.DecodeShuffleTable[lower],
-		&shared.DecodeShuffleTable[upper],
-		sizeLower,
-	)
-	return int(sizeLower + sizeUpper)
+	return int(get8uint32Fast(in, out, ctrl,
+		shared.DecodeShuffleTable,
+		shared.PerControlLenTable,
+	))
 }
 
-func get8uint32Fast(in []byte, out []uint32, shufA *[16]uint8, shufB *[16]uint8, lenA uint8)
+func get8uint32Fast(
+	in []byte, out []uint32, ctrl uint16,
+	shuffle *[256][16]uint8, lenTable *[256]uint8,
+) (r uint64)

--- a/pkg/decode/decode_amd64.s
+++ b/pkg/decode/decode_amd64.s
@@ -2,19 +2,36 @@
 
 #include "textflag.h"
 
-// func get8uint32Fast(in []byte, out []uint32, shufA *[16]uint8, shufB *[16]uint8, lenA uint8)
+// func get8uint32Fast(in []byte, out []uint32, ctrl uint16, shuffle *[256][16]uint8, lenTable *[256]uint8) (r uint64)
 // Requires: AVX
-TEXT ·get8uint32Fast(SB), NOSPLIT, $0-72
-	MOVQ    shufA+48(FP), AX
-	MOVQ    shufB+56(FP), CX
-	MOVQ    in_base+0(FP), DX
-	MOVQ    DX, BX
-	MOVBQZX lenA+64(FP), SI
-	ADDQ    SI, BX
-	VLDDQU  (DX), X0
-	VLDDQU  (BX), X1
-	VPSHUFB (AX), X0, X0
-	VPSHUFB (CX), X1, X1
+TEXT ·get8uint32Fast(SB), NOSPLIT, $0-80
+	MOVWQZX ctrl+48(FP), AX
+	MOVQ    shuffle+56(FP), CX
+	MOVBQZX AL, DX
+	SHLQ    $0x04, DX
+	ADDQ    CX, DX
+	MOVWQZX AX, BX
+	SHRQ    $0x08, BX
+	SHLQ    $0x04, BX
+	ADDQ    CX, BX
+	MOVQ    in_base+0(FP), CX
+	MOVQ    CX, SI
+	MOVQ    lenTable+64(FP), DI
+	MOVBQZX AL, R8
+	ADDQ    DI, R8
+	MOVBQZX (R8), R8
+	ADDQ    R8, SI
+	MOVQ    lenTable+64(FP), DI
+	MOVWQZX AX, AX
+	SHRQ    $0x08, AX
+	ADDQ    DI, AX
+	MOVBQZX (AX), AX
+	ADDQ    AX, R8
+	MOVQ    R8, r+72(FP)
+	VLDDQU  (CX), X0
+	VLDDQU  (SI), X1
+	VPSHUFB (DX), X0, X0
+	VPSHUFB (BX), X1, X1
 	MOVQ    out_base+24(FP), AX
 	VMOVDQU X0, (AX)
 	VMOVDQU X1, 16(AX)

--- a/pkg/decode/main/asm.go
+++ b/pkg/decode/main/asm.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/mmcloughlin/avo/build"
 	"github.com/mmcloughlin/avo/operand"
+	"github.com/mmcloughlin/avo/reg"
 )
 
 const (
@@ -12,34 +13,39 @@ const (
 
 	pIn    = "in"
 	pOut   = "out"
-	pShufA = "shufA"
-	pShufB = "shufB"
-	pLenA  = "lenA"
+	pCtrl  = "ctrl"
+	pShuffle = "shuffle"
+	pLenTable  = "lenTable"
+	pR 			= "r"
 )
 
 var (
 	signature = fmt.Sprintf(
-		"func(%s []byte, %s []uint32, %s, %s *[16]uint8, %s uint8)",
-		pIn, pOut, pShufA, pShufB, pLenA)
+		"func(%s []byte, %s []uint32, %s uint16, %s *[256][16]uint8, %s *[256]uint8) (%s uint64)",
+		pIn, pOut, pCtrl, pShuffle, pLenTable, pR)
 )
 
 func main() {
 	TEXT(name, NOSPLIT, signature)
-	Doc("get8uint32Fast decodes 8 32-bit unsigned integers at a time.")
 
-	shuffleA := operand.Mem{
-		Base: Load(Param(pShufA), GP64()),
-	}
-
-	shuffleB := operand.Mem{
-		Base: Load(Param(pShufB), GP64()),
-	}
+	ctrl := GP64()
+	Load(Param(pCtrl), ctrl)
+	shuffleBase := Load(Param(pShuffle), GP64())
+	shuffleA := loadCtrl16Shuffle(shuffleBase, ctrl, false)
+	shuffleB := loadCtrl16Shuffle(shuffleBase, ctrl, true)
 
 	firstBlock := Load(Param(pIn).Base(), GP64())
 	secondBlock := GP64()
 	MOVQ(firstBlock, secondBlock)
-	size := Load(Param(pLenA), GP64())
-	ADDQ(size, secondBlock)
+	lowerSize := loadLenValue(ctrl, false)
+
+	MOVBQZX(operand.Mem{Base: lowerSize}, lowerSize)
+	ADDQ(lowerSize, secondBlock)
+
+	upperSize := loadLenValue(ctrl, true)
+	MOVBQZX(operand.Mem{Base: upperSize}, upperSize)
+	ADDQ(upperSize, lowerSize)
+	Store(lowerSize, Return(pR))
 
 	firstFour := XMM()
 	secondFour := XMM()
@@ -56,4 +62,33 @@ func main() {
 
 	RET()
 	Generate()
+}
+
+func loadCtrl16Shuffle(shuffleBase reg.Register, ctrl reg.GPVirtual, upper bool) operand.Mem {
+	a := GP64()
+	if upper {
+		MOVWQZX(ctrl.As16(), a)
+		SHRQ(operand.Imm(8), a)
+	} else {
+		MOVBQZX(ctrl.As8(), a)
+	}
+
+	// Left shift by 4 to get the byte level offset for the shuffle table
+	SHLQ(operand.Imm(4), a)
+	ADDQ(shuffleBase, a)
+
+	return operand.Mem{Base: a}
+}
+
+func loadLenValue(ctrl reg.GPVirtual, upper bool) reg.GPVirtual {
+	lt := Load(Param(pLenTable), GP64())
+	lenValue := GP64()
+	if upper {
+		MOVWQZX(ctrl.As16(), lenValue)
+		SHRQ(operand.Imm(8), lenValue)
+	} else {
+		MOVBQZX(ctrl.As8L(), lenValue)
+	}
+	ADDQ(lt, lenValue)
+	return lenValue
 }

--- a/pkg/encode/encode_amd64.go
+++ b/pkg/encode/encode_amd64.go
@@ -15,10 +15,10 @@ func GetMode() shared.PerformanceMode {
 }
 
 func put8uint32(in []uint32, out []byte) uint16 {
-	// bounds check to prevent undefined behavior
-	_ = in[7]
-	_ = out[31]
-	return put8uint32Fast(in, out, shared.EncodeShuffleTable, shared.PerControlLenTable)
+	return put8uint32Fast(in, out,
+		shared.EncodeShuffleTable,
+		shared.PerControlLenTable,
+	)
 }
 
 func put8uint32Fast(

--- a/pkg/encode/main/asm.go
+++ b/pkg/encode/main/asm.go
@@ -31,7 +31,6 @@ var (
 
 func main() {
 	TEXT(name, NOSPLIT, signature)
-	Doc("put8uint32Fast encodes 8 32-bit unsigned integers at a time.")
 
 	mask1111R := ConstData(mask1111Str, operand.U16(mask1111))
 	mask7F00R := ConstData(mask7F00Str, operand.U16(mask7F00))


### PR DESCRIPTION
Cuts the decode speed in half by moving all of the necessary accesses to the shuffle and len table into assembly code. This likely resulted in a 3 ns drop due to inlining of the fast func in the benchmark code