### PR TITLE
Benchmarks: Add throughput and stdlib Varint

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,17 @@ goos: darwin
 goarch: amd64
 pkg: github.com/theMPatel/streamvbyte-simdgo/pkg/decode
 cpu: Intel(R) Core(TM) i7-8700B CPU @ 3.20GHz
-BenchmarkGet8uint32Fast-12      	319653280	         3.754 ns/op
-BenchmarkGet8uint32Scalar-12    	22984789	        51.96 ns/op
+BenchmarkGet8uint32Fast-12      	315457458	         3.808 ns/op	8403.62 MB/s
+BenchmarkGet8uint32Scalar-12    	22839368	        52.67 ns/op	 607.57 MB/s
+BenchmarkGet8uint32Varint-12    	21459482	        56.23 ns/op	 569.07 MB/s
 
 goos: darwin
 goarch: amd64
 pkg: github.com/theMPatel/streamvbyte-simdgo/pkg/encode
 cpu: Intel(R) Core(TM) i7-8700B CPU @ 3.20GHz
-BenchmarkPut8uint32Fast-12      	324639439	         3.711 ns/op
-BenchmarkPut8uint32Scalar-12    	46963490	        25.66 ns/op
+BenchmarkPut8uint32Fast-12      	320733799	         3.745 ns/op	8544.96 MB/s
+BenchmarkPut8uint32Scalar-12    	46435694	        25.66 ns/op	1246.90 MB/s
+BenchmarkPut8uint32Varint-12    	44864949	        26.81 ns/op	1193.64 MB/s
 ```
 
 ---

--- a/pkg/encode/encode_test.go
+++ b/pkg/encode/encode_test.go
@@ -62,7 +62,7 @@ func TestPut8uint32Fast(t *testing.T) {
 	}
 }
 
-var ctrlSinkA uint16
+var writeSinkA uint16
 
 func BenchmarkPut8uint32Fast(b *testing.B) {
 	count := 8
@@ -78,10 +78,10 @@ func BenchmarkPut8uint32Fast(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ctrl = put8uint32(nums, out)
 	}
-	ctrlSinkA = ctrl
+	writeSinkA = ctrl
 }
 
-var ctrlSinkB uint16
+var writeSinkB uint16
 
 func BenchmarkPut8uint32Scalar(b *testing.B) {
 	count := 8
@@ -97,10 +97,10 @@ func BenchmarkPut8uint32Scalar(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ctrl = Put8uint32Scalar(nums, out)
 	}
-	ctrlSinkB = ctrl
+	writeSinkB = ctrl
 }
 
-var sinkC int
+var writeSinkC int
 
 func BenchmarkPut8uint32Varint(b *testing.B) {
 	count := 8
@@ -117,7 +117,7 @@ func BenchmarkPut8uint32Varint(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		written = write8Varint(nums, out)
 	}
-	sinkC = written
+	writeSinkC = written
 }
 
 func write8Varint(nums []uint32, out []byte) int {


### PR DESCRIPTION
Adds throughput to the benchmark data in the readme, includes benchmark comparisons to the stdlib varint format