### PR TITLE
Randutils: Add package for more uniform random numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,16 @@ There are several existing implementations:
 ```
 goos: darwin
 goarch: amd64
+pkg: github.com/theMPatel/streamvbyte-simdgo/pkg
+cpu: Intel(R) Core(TM) i7-8700B CPU @ 3.20GHz
+--
+BenchmarkCopy-12    	464051004	         2.584 ns/op	12381.91 MB/s
+
+goos: darwin
+goarch: amd64
 pkg: github.com/theMPatel/streamvbyte-simdgo/pkg/decode
 cpu: Intel(R) Core(TM) i7-8700B CPU @ 3.20GHz
+--
 BenchmarkGet8uint32Fast-12      	315457458	         3.808 ns/op	8403.62 MB/s
 BenchmarkGet8uint32Scalar-12    	22839368	        52.67 ns/op	 607.57 MB/s
 BenchmarkGet8uint32Varint-12    	21459482	        56.23 ns/op	 569.07 MB/s
@@ -28,6 +36,7 @@ goos: darwin
 goarch: amd64
 pkg: github.com/theMPatel/streamvbyte-simdgo/pkg/encode
 cpu: Intel(R) Core(TM) i7-8700B CPU @ 3.20GHz
+--
 BenchmarkPut8uint32Fast-12      	320733799	         3.745 ns/op	8544.96 MB/s
 BenchmarkPut8uint32Scalar-12    	46435694	        25.66 ns/op	1246.90 MB/s
 BenchmarkPut8uint32Varint-12    	44864949	        26.81 ns/op	1193.64 MB/s

--- a/pkg/decode/decode_amd64.go
+++ b/pkg/decode/decode_amd64.go
@@ -21,6 +21,7 @@ func get8uint32(in []byte, out []uint32, ctrl uint16) int {
 	))
 }
 
+//go:noescape
 func get8uint32Fast(
 	in []byte, out []uint32, ctrl uint16,
 	shuffle *[256][16]uint8, lenTable *[256]uint8,

--- a/pkg/decode/decode_test.go
+++ b/pkg/decode/decode_test.go
@@ -2,9 +2,10 @@ package decode
 
 import (
 	"encoding/binary"
-	"math/rand"
 	"reflect"
 	"testing"
+
+	"github.com/theMPatel/streamvbyte-simdgo/pkg/randutils"
 )
 
 func TestGet8uint32Scalar(t *testing.T) {
@@ -115,7 +116,7 @@ func generate8Varint() []byte {
 	)
 
 	for i := 0; i < count; i++ {
-		size := binary.PutUvarint(buf, uint64(rand.Uint32()))
+		size := binary.PutUvarint(buf, uint64(randutils.RandUint32()))
 		data = append(data, buf[:size]...)
 		written += size
 	}

--- a/pkg/decode/decode_test.go
+++ b/pkg/decode/decode_test.go
@@ -2,11 +2,17 @@ package decode
 
 import (
 	"encoding/binary"
+	"math/rand"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/theMPatel/streamvbyte-simdgo/pkg/randutils"
 )
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 func TestGet8uint32Scalar(t *testing.T) {
 	in := []byte{

--- a/pkg/encode/encode_amd64.go
+++ b/pkg/encode/encode_amd64.go
@@ -21,6 +21,7 @@ func put8uint32(in []uint32, out []byte) uint16 {
 	)
 }
 
+//go:noescape
 func put8uint32Fast(
 	in []uint32, outBytes []byte,
 	shuffle *[256][16]uint8, lenTable *[256]uint8,

--- a/pkg/encode/encode_test.go
+++ b/pkg/encode/encode_test.go
@@ -2,12 +2,18 @@ package encode
 
 import (
 	"encoding/binary"
+	"math/rand"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/theMPatel/streamvbyte-simdgo/pkg/randutils"
 	"github.com/theMPatel/streamvbyte-simdgo/pkg/shared"
 )
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 func TestPut8uint32Scalar(t *testing.T) {
 	in := []uint32{1024, 3, 2, 1, 1_073_741_824, 10, 12, 1024}

--- a/pkg/encode/encode_test.go
+++ b/pkg/encode/encode_test.go
@@ -2,17 +2,12 @@ package encode
 
 import (
 	"encoding/binary"
-	"math/rand"
 	"reflect"
 	"testing"
-	"time"
 
+	"github.com/theMPatel/streamvbyte-simdgo/pkg/randutils"
 	"github.com/theMPatel/streamvbyte-simdgo/pkg/shared"
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 func TestPut8uint32Scalar(t *testing.T) {
 	in := []uint32{1024, 3, 2, 1, 1_073_741_824, 10, 12, 1024}
@@ -42,7 +37,7 @@ func TestPut8uint32Fast(t *testing.T) {
 	count := 8
 	nums := make([]uint32, count)
 	for i := 0; i < count; i++ {
-		nums[i] = rand.Uint32()
+		nums[i] = randutils.RandUint32()
 	}
 
 	out := make([]byte, MaxBytesPerNum*count)
@@ -68,7 +63,7 @@ func BenchmarkPut8uint32Fast(b *testing.B) {
 	count := 8
 	nums := make([]uint32, count)
 	for i := 0; i < count; i++ {
-		nums[i] = rand.Uint32()
+		nums[i] = randutils.RandUint32()
 	}
 	out := make([]byte, MaxBytesPerNum*count)
 
@@ -87,7 +82,7 @@ func BenchmarkPut8uint32Scalar(b *testing.B) {
 	count := 8
 	nums := make([]uint32, count)
 	for i := 0; i < count; i++ {
-		nums[i] = rand.Uint32()
+		nums[i] = randutils.RandUint32()
 	}
 	out := make([]byte, MaxBytesPerNum*count)
 
@@ -106,7 +101,7 @@ func BenchmarkPut8uint32Varint(b *testing.B) {
 	count := 8
 	nums := make([]uint32, count)
 	for i := 0; i < count; i++ {
-		nums[i] = rand.Uint32()
+		nums[i] = randutils.RandUint32()
 	}
 
 	out := make([]byte, binary.MaxVarintLen32*count)

--- a/pkg/pkg_test.go
+++ b/pkg/pkg_test.go
@@ -1,13 +1,19 @@
 package pkg
 
 import (
+	"math/rand"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/theMPatel/streamvbyte-simdgo/pkg/decode"
 	"github.com/theMPatel/streamvbyte-simdgo/pkg/encode"
 	"github.com/theMPatel/streamvbyte-simdgo/pkg/randutils"
 )
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 func TestRoundTripScalar(t *testing.T) {
 	in := []uint32{1024, 3, 2, 1, 1_073_741_824, 10, 12, 1024}

--- a/pkg/pkg_test.go
+++ b/pkg/pkg_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/theMPatel/streamvbyte-simdgo/pkg/decode"
 	"github.com/theMPatel/streamvbyte-simdgo/pkg/encode"
+	"github.com/theMPatel/streamvbyte-simdgo/pkg/randutils"
 )
 
 func TestRoundTripScalar(t *testing.T) {
@@ -37,5 +38,20 @@ func TestRoundTripScalar(t *testing.T) {
 
 	if !reflect.DeepEqual(in, decoded) {
 		t.Fatalf("expected %+v, actual %+v", in, decoded)
+	}
+}
+
+func BenchmarkCopy(b *testing.B) {
+	count := 8
+	nums := make([]uint32, count)
+	for i := 0; i < count; i++ {
+		nums[i] = randutils.RandUint32()
+	}
+
+	dest := make([]uint32, count)
+	b.SetBytes(32)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		copy(dest, nums)
 	}
 }

--- a/pkg/randutils/randutils.go
+++ b/pkg/randutils/randutils.go
@@ -10,12 +10,7 @@ package randutils
 import (
 	"math"
 	"math/rand"
-	"time"
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 type generator func() uint32
 

--- a/pkg/randutils/randutils.go
+++ b/pkg/randutils/randutils.go
@@ -1,0 +1,53 @@
+package randutils
+
+// This file provides a more uniform random number generator that creates
+// numbers that have a more normal distribution along the number of bytes
+// required to encode them. This is needed because the larger encoded bytes
+// i.e. 3 and 4 bytes have more numbers to pick from versus those that require
+// just 1 or 2. Thus, using a normally generated number is more likely to produce
+// a number that requires 3 or 4 bytes to encode.
+
+import (
+	"math"
+	"math/rand"
+	"time"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+type generator func() uint32
+
+func randUint32Range(low, high uint32) uint32 {
+	return (rand.Uint32() % (high-low+1))+low
+}
+
+var (
+	generators = []generator{
+		// 1 byte,
+		func() uint32 {
+			return randUint32Range(0, 1<<8)
+		},
+		// 2 byte,
+		func() uint32 {
+			return randUint32Range(1<<8, 1<<16)
+		},
+		// 3 byte,
+		func() uint32 {
+			return randUint32Range(1<<16, 1<<24)
+		},
+		// 4 byte,
+		func() uint32 {
+			return randUint32Range(1<<24, math.MaxUint32)
+		},
+	}
+)
+
+// RandUint32 generates a random number that is also uniformly random
+// on the axis for the number of bytes required to encode it. It first
+// randomly chooses a byte length, i.e. 1, 2, 3 or 4 and then randomly
+// generates a number whose encoded length would be that length.
+func RandUint32() uint32 {
+	return generators[rand.Int()%4]()
+}


### PR DESCRIPTION
Includes some updates to add a random number generator that is more uniform towards the number of bytes required to encode the random number.

Includes more benchmark updates.

Includes a `//go:noescape` pragma for the assembly stubs to indicate that the func args don't escape and thus don't require heap allocation.